### PR TITLE
Combatant notes

### DIFF
--- a/app/controllers/combatants_controller.rb
+++ b/app/controllers/combatants_controller.rb
@@ -2,7 +2,7 @@ class CombatantsController < ApplicationController
   def index; end
 
   def create
-    data = params.require(:combatant).permit(:name, :time, :effect, :active)
+    data = params.require(:combatant).permit(:name, :time, :notes, :active)
     cmb = Combatant.create(data)
     render json: cmb
   end
@@ -20,7 +20,7 @@ class CombatantsController < ApplicationController
 
   def update
     id = params.require(:id)
-    data = params.require(:combatant).permit(:name, :time, :effect, :active)
+    data = params.require(:combatant).permit(:name, :time, :notes, :active)
     cmb = Combatant.find(id)
     cmb.update(data)
     render json: cmb

--- a/app/views/combatants/edit.html.erb
+++ b/app/views/combatants/edit.html.erb
@@ -13,14 +13,20 @@
       <% end %>
 
       <%= tag.div(class: %w(modal-body)) do %>
-        <%= tag.div(class: %w(form-group row)) do %>
-          <%= tag.div(class: %w(col-sm-9)) do %>
+        <%= tag.div(class: %w(row mb-3)) do %>
+          <%= tag.div(class: %w(form-group col-sm-9)) do %>
             <%= form.label(:name)  %>
             <%= form.text_field(:name, class: 'form-control') %>
           <% end %>
-          <%= tag.div(class: %w(col-sm-3)) do %>
+          <%= tag.div(class: %w(form-group col-sm-3)) do %>
             <%= form.label(:time) %>
             <%= form.text_field(:time, class: %w(form-control col-xs-2)) %>
+          <% end %>
+        <% end %>
+        <%= tag.div(class: %w(row)) do %>
+          <%= tag.div(class: %w(form-group col)) do %>
+            <%= form.label(:notes)  %>
+            <%= form.text_field(:notes, class: 'form-control') %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/combatants/list.html.erb
+++ b/app/views/combatants/list.html.erb
@@ -7,6 +7,7 @@
       <%= tag.i(class: %w(bi bi-trash-fill text-primary delete-button)) %>
       <%= tag.span(c.name, class: %w(ms-3)) %>
     <% end %>
+    <%= tag.span(c.notes) %>
     <%= tag.span(c.time, class: %w(badge bg-primary rounded-pill)) %>
   <% end %>
 <% end %>

--- a/app/webpacker/packs/combat.js
+++ b/app/webpacker/packs/combat.js
@@ -149,9 +149,8 @@ function prepareEditForm(ajaxBody) {
 
   const myForm = document.getElementById('object-form');
   const submitButton = document.getElementById('object-modal-ok');
-  submitButton.addEventListener('click', _ => {
-    Helpers.submitFormAndReloadPage(myForm, fetchCombatantsList);
-  });
+  submitButton.addEventListener('click', _ =>
+    Helpers.submitFormAndReloadPage(myForm, fetchCombatantsList));
 
   const formInputs = myForm.querySelectorAll('input.form-control');
   myModal.addEventListener('shown.bs.modal', _ => { formInputs[0].focus() });
@@ -178,6 +177,11 @@ function rotateTurn() {
 window.addEventListener('load', _ => {
   csrfParam = document.querySelector('meta[name="csrf-param"]').getAttribute('content');
   csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const myModal = document.getElementById('object-modal');
+  myModal.addEventListener('keydown', ev => {
+    if (ev.code === 'Enter') { document.getElementById('object-modal-ok').click(); }
+  });
 
   const newButton = document.getElementById('new-btn');
   newButton.addEventListener('click', openNewModal);

--- a/app/webpacker/src/stylesheets/application.scss
+++ b/app/webpacker/src/stylesheets/application.scss
@@ -1,3 +1,7 @@
+i.bi {
+  margin-right: ($spacer * .25) !important;
+}
+
 #detail-modal {
   table {
     th, td {

--- a/db/migrate/20210123005051_combatants_effect_string.rb
+++ b/db/migrate/20210123005051_combatants_effect_string.rb
@@ -1,0 +1,11 @@
+class CombatantsEffectString < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :combatants, :effect
+    add_column :combatants, :notes, :string
+  end
+
+  def down
+    remove_column :combatants, :notes
+    add_column :combatants, :effect, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_11_023119) do
+ActiveRecord::Schema.define(version: 2021_01_23_005051) do
 
   create_table "caster_classes", force: :cascade do |t|
     t.string "name", limit: 255
@@ -44,10 +44,10 @@ ActiveRecord::Schema.define(version: 2021_01_11_023119) do
   create_table "combatants", force: :cascade do |t|
     t.string "name", limit: 255
     t.integer "time"
-    t.integer "effect"
     t.boolean "active"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "notes"
   end
 
   create_table "spells", force: :cascade do |t|


### PR DESCRIPTION
Fixes #12.

I decided to replace the `effects` field with a more generic `notes` field, figuring it will be easier to use if it's freeform. D&D5 has a lot of effects, many of which are pretty rare, and the idea of having badges for statuses is neat but I would hate to only limit it to the stuff I can code for. I could have put a bunch of work into a dynamic system of statuses and badge colors etc. but didn't think it was worth it.