### PR TITLE
Update Capybara to use headless Chrome instead of Firefox

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,1 +1,3 @@
 require 'capybara/rspec'
+
+Capybara.javascript_driver = :selenium_chrome_headless


### PR DESCRIPTION
"Heady" Firefox started throwing profile errors locally, so I switched it over to headless Chrome and that seems to be working better. (Heady Chrome also worked.)